### PR TITLE
begin using billing telephone for order and invoice sms notifications.

### DIFF
--- a/Controller/Adminhtml/Invoice/Send.php
+++ b/Controller/Adminhtml/Invoice/Send.php
@@ -58,21 +58,16 @@ class Send extends Action
 
       $order = $invoice->getOrder();
 
-      /** TODO: this is not clean */
-      if(!$shippingAddress = $order->getShippingAddress()) {
-        $this->messageManager->addErrorMessage(__('The order does not have a shipping address.'));
+      $billingAddress = $order->getBillingAddress();
 
-        return $resultRedirect;
-      }
-
-      if($shippingAddress->getSmsAlert()) {
+      if($billingAddress->getSmsAlert()) {
         $result = $this->_invoiceAdapter->sendOrderSms($invoice);
         $this->messageManager->addSuccessMessage(__('The SMS has been sent.'));
 
         return $resultRedirect;
       }
 
-      $this->messageManager->addErrorMessage(__('The shipping telephone number did not opt-in for SMS notifications.'));
+      $this->messageManager->addErrorMessage(__('The billing telephone number did not opt-in for SMS notifications.'));
 
       return $resultRedirect;
     }

--- a/Controller/Adminhtml/Order/Send.php
+++ b/Controller/Adminhtml/Order/Send.php
@@ -56,21 +56,16 @@ class Send extends Action
         ['order_id' => $order->getEntityId()]
       );
 
-      /** TODO: this is not clean */
-      if(!$shippingAddress = $order->getShippingAddress()) {
-        $this->messageManager->addErrorMessage(__('The order does not have a shipping address.'));
+      $billingAddress = $order->getBillingAddress();
 
-        return $resultRedirect;
-      }
-
-      if($shippingAddress->getSmsAlert()) {
+      if($billingAddress->getSmsAlert()) {
         $result = $this->_orderAdapter->sendOrderSms($order);
         $this->messageManager->addSuccessMessage(__('The SMS has been sent.'));
 
         return $resultRedirect;
       }
 
-      $this->messageManager->addErrorMessage(__('The shipping telephone number did not opt-in for SMS notifications.'));
+      $this->messageManager->addErrorMessage(__('The billing telephone number did not opt-in for SMS notifications.'));
 
       return $resultRedirect;
     }

--- a/Model/Adapter/Order.php
+++ b/Model/Adapter/Order.php
@@ -36,7 +36,7 @@ class Order extends AdapterAbstract
 
     //TODO: something needs to verify the phone number
     //      and add country code
-    $this->_recipientPhone = '+1' . $order->getShippingAddress()->getTelephone();
+    $this->_recipientPhone = '+1' . $order->getBillingAddress()->getTelephone();
 
     try {
       $this->_smsStatus = $this->_sendSms();
@@ -56,8 +56,8 @@ class Order extends AdapterAbstract
 
     $vars['order.increment_id'] = $order->getIncrementId();
     $vars['order.qty'] = $order->getTotalQtyOrdered();
-    $vars['shipment.firstname'] = $order->getShippingAddress()->getFirstname();
-    $vars['shipment.lastname'] = $order->getShippingAddress()->getLastname();
+    $vars['billing.firstname'] = $order->getBillingAddress()->getFirstname();
+    $vars['billing.lastname'] = $order->getBillingAddress()->getLastname();
     $vars['order.grandtotal'] = $order->getGrandTotal(); //TODO: not properly formatted
     $vars['storename'] = $this->_storeManager->getWebsite(
         $this->_storeManager->getStore($order->getStoreId())->getWebsiteId()

--- a/Model/Adapter/Order/Invoice.php
+++ b/Model/Adapter/Order/Invoice.php
@@ -38,7 +38,7 @@ class Invoice extends AdapterAbstract
 
     //TODO: something needs to verify the phone number
     //      and add country code
-    $this->_recipientPhone = '+1' . $order->getShippingAddress()->getTelephone();
+    $this->_recipientPhone = '+1' . $order->getBillingAddress()->getTelephone();
 
     try {
       $this->_smsStatus = $this->_sendSms();
@@ -61,8 +61,8 @@ class Invoice extends AdapterAbstract
     $vars['invoice.increment_id'] = $invoice->getIncrementId();
     $vars['order.increment_id'] = $invoice->getOrder()->getIncrementId();
     $vars['order.qty'] = $invoice->getOrder()->getTotalQtyOrdered();
-    $vars['shipment.firstname'] = $invoice->getOrder()->getShippingAddress()->getFirstname();
-    $vars['shipment.lastname'] = $invoice->getOrder()->getShippingAddress()->getLastname();
+    $vars['billing.firstname'] = $invoice->getOrder()->getBillingAddress()->getFirstname();
+    $vars['billing.lastname'] = $invoice->getOrder()->getBillingAddress()->getLastname();
     $vars['storename'] = $this->_storeManager->getWebsite(
         $this->_storeManager->getStore($invoice->getOrder()->getStoreId())->getWebsiteId()
       )->getName();

--- a/Observer/Sales/Order/Invoice/Register.php
+++ b/Observer/Sales/Order/Invoice/Register.php
@@ -53,9 +53,9 @@ class Register implements ObserverInterface
     $invoice = $observer->getInvoice();
     $order = $invoice->getOrder();
 
-    if (!$shippingAddress = $order->getShippingAddress()) { return $observer; }
+    $billingAddress = $order->getBillingAddress();
 
-    if($shippingAddress->getSmsAlert()) {
+    if($billingAddress->getSmsAlert()) {
       $this->_invoiceAdapter->sendOrderSms($invoice);
     }
 

--- a/Observer/Sales/OrderAfter.php
+++ b/Observer/Sales/OrderAfter.php
@@ -43,7 +43,6 @@ class OrderAfter implements ObserverInterface
 
   /**
    * @param \Magento\Framework\Event\Observer $observer
-   * @var \Magento\Sales\Model\Order $order
    * @return \Magento\Framework\Event\Observer
    */
   public function execute(\Magento\Framework\Event\Observer $observer)
@@ -52,9 +51,9 @@ class OrderAfter implements ObserverInterface
 
     $order = $observer->getOrder();
 
-    if(!$shippingAddress = $order->getShippingAddress()) { return $observer; }
+    $billingAddress = $order->getBillingAddress();
 
-    if($shippingAddress->getSmsAlert()) {
+    if($billingAddress->getSmsAlert()) {
       $this->_orderAdapter->sendOrderSms($order);
     }
 

--- a/Plugin/Checkout/Block/Checkout/LayoutProcessor.php
+++ b/Plugin/Checkout/Block/Checkout/LayoutProcessor.php
@@ -46,18 +46,19 @@ class LayoutProcessor
   ) {
     if(!$this->_helper->isTwilioEnabled()) { return $jsLayout; }
 
+    //Add to shipping form
     $jsLayout['components']['checkout']['children']['steps']['children']['shipping-step']['children']
     ['shippingAddress']['children']['shipping-address-fieldset']['children']['sms_alert'] = [
       'component' => 'Magento_Ui/js/form/element/abstract',
       'config' => [
-        'customScope' => 'shippingAddress',
+        'customScope' => 'shippingAddress.custom_attributes',
         'template' => 'ui/form/field',
         'elementTmpl' => 'ui/form/element/checkbox',
         'custom_entry' => null,
       ],
       'dataScope' => 'shippingAddress.custom_attributes.sms_alert',
-      'label' => 'SMS Order Notifications',
-      'description' => 'Send SMS order notifications to the phone number above.',
+      'label' => __('SMS Order Notifications'),
+      'description' => __('Send SMS order notifications to the phone number above.'),
       'provider' => 'checkoutProvider',
       'visible' => true,
       'checked' => true,
@@ -65,6 +66,34 @@ class LayoutProcessor
       'sortOrder' => 125,
       'custom_entry' => null,
     ];
+
+    //Add to billing form
+    /*$billingConfiguration = $jsLayout['components']['checkout']['children']['steps']['children']['billing-step']['children']['payment']['children']['payments-list']['children'];
+    foreach($billingConfiguration as $paymentGroup => $groupConfig) {
+      if (isset($groupConfig['component']) AND $groupConfig['component'] === 'Magento_Checkout/js/view/billing-address') {
+
+        $jsLayout['components']['checkout']['children']['steps']['children']['billing-step']['children']
+        ['payment']['children']['payments-list']['children'][$paymentGroup]['children']['form-fields']['children']['custom_attribute_code'] = [
+          'component' => 'Magento_Ui/js/form/element/abstract',
+          'config' => [
+            'template' => 'ui/form/field',
+            'elementTmpl' => 'ui/form/element/checkbox',
+            'custom_entry' => null,
+            'id' => 'sms_alert',
+          ],
+          'dataScope' => $groupConfig['dataScopePrefix'] . '.sms_alert',
+          'label' => __('SMS Order Notifications'),
+          'description' => __('Send SMS order notifications to the phone number above.'),
+          'provider' => 'checkoutProvider',
+          'visible' => true,
+          'checked' => true,
+          'validation' => [],
+          'sortOrder' => 125,
+          'custom_entry' => null,
+          'id' => 'sms_alert'
+        ];
+      }
+    }*/
 
     return $jsLayout;
   }

--- a/Plugin/Checkout/Model/GuestPaymentInformationManagement.php
+++ b/Plugin/Checkout/Model/GuestPaymentInformationManagement.php
@@ -17,21 +17,17 @@
 
 namespace Pmclain\Twilio\Plugin\Checkout\Model;
 
-class ShippingInformationManagement
+class GuestPaymentInformationManagement
 {
-  public function beforeSaveAddressInformation(
-    \Magento\Checkout\Model\ShippingInformationManagement $subject,
-    $cartId,
-    \Magento\Checkout\Api\Data\ShippingInformationInterface $addressInformation
-  ) {
-    $shippingAddress = $addressInformation->getShippingAddress();
-    $billingAddress = $addressInformation->getBillingAddress();
 
-    if ($shippingAddress->getExtensionAttributes()) {
-      $shippingAddress->setSmsAlert((int)$shippingAddress->getExtensionAttributes()->getSmsAlert());
-    }else {
-      $shippingAddress->setSmsAlert(0);
-    }
+  public function beforeSavePaymentInformation(
+    \Magento\Checkout\Model\GuestPaymentInformationManagement $subject,
+    $cartId,
+    $email,
+    \Magento\Quote\Api\Data\PaymentInterface $paymentMethod,
+    \Magento\Quote\Api\Data\AddressInterface $billingAddress = null
+  ) {
+    if (!$billingAddress) { return; }
 
     if ($billingAddress->getExtensionAttributes()) {
       $billingAddress->setSmsAlert((int)$billingAddress->getExtensionAttributes()->getSmsAlert());

--- a/Plugin/Checkout/Model/PaymentInformationManagement.php
+++ b/Plugin/Checkout/Model/PaymentInformationManagement.php
@@ -17,21 +17,16 @@
 
 namespace Pmclain\Twilio\Plugin\Checkout\Model;
 
-class ShippingInformationManagement
+class PaymentInformationManagement
 {
-  public function beforeSaveAddressInformation(
-    \Magento\Checkout\Model\ShippingInformationManagement $subject,
-    $cartId,
-    \Magento\Checkout\Api\Data\ShippingInformationInterface $addressInformation
-  ) {
-    $shippingAddress = $addressInformation->getShippingAddress();
-    $billingAddress = $addressInformation->getBillingAddress();
 
-    if ($shippingAddress->getExtensionAttributes()) {
-      $shippingAddress->setSmsAlert((int)$shippingAddress->getExtensionAttributes()->getSmsAlert());
-    }else {
-      $shippingAddress->setSmsAlert(0);
-    }
+  public function beforeSavePaymentInformation(
+    \Magento\Checkout\Model\PaymentInformationManagement $subject,
+    $cartId,
+    \Magento\Quote\Api\Data\PaymentInterface $paymentMethod,
+    \Magento\Quote\Api\Data\AddressInterface $billingAddress = null
+  ) {
+    if (!$billingAddress) { return; }
 
     if ($billingAddress->getExtensionAttributes()) {
       $billingAddress->setSmsAlert((int)$billingAddress->getExtensionAttributes()->getSmsAlert());

--- a/Test/Unit/Conroller/Adminhtml/Invoice/SendTest.php
+++ b/Test/Unit/Conroller/Adminhtml/Invoice/SendTest.php
@@ -150,7 +150,7 @@ class SendTest extends \PHPUnit_Framework_TestCase
 
     $this->orderMock = $this->getMockBuilder(Order::class)
       ->disableOriginalConstructor()
-      ->setMethods(['getShippingAddress'])
+      ->setMethods(['getBillingAddress'])
       ->getMock();
 
     $this->addressMock = $this->getMockBuilder(Address::class)
@@ -232,7 +232,7 @@ class SendTest extends \PHPUnit_Framework_TestCase
       ->willReturn($this->orderMock);
 
     $this->orderMock->expects($this->once())
-      ->method('getShippingAddress')
+      ->method('getBillingAddress')
       ->willReturn($this->addressMock);
 
     $this->addressMock->expects($this->once())
@@ -291,7 +291,7 @@ class SendTest extends \PHPUnit_Framework_TestCase
       ->willReturn($this->orderMock);
 
     $this->orderMock->expects($this->once())
-      ->method('getShippingAddress')
+      ->method('getBillingAddress')
       ->willReturn($this->addressMock);
 
     $this->addressMock->expects($this->once())
@@ -303,7 +303,7 @@ class SendTest extends \PHPUnit_Framework_TestCase
 
     $this->messageManagerMock->expects($this->once())
       ->method('addErrorMessage')
-      ->with('The shipping telephone number did not opt-in for SMS notifications.')
+      ->with('The billing telephone number did not opt-in for SMS notifications.')
       ->willReturnSelf();
 
     $this->resultRedirectMock->expects($this->once())

--- a/Test/Unit/Conroller/Adminhtml/Order/SendTest.php
+++ b/Test/Unit/Conroller/Adminhtml/Order/SendTest.php
@@ -141,7 +141,7 @@ class SendTest extends \PHPUnit_Framework_TestCase
 
     $this->orderMock = $this->getMockBuilder(Order::class)
       ->disableOriginalConstructor()
-      ->setMethods(['getShippingAddress', 'getEntityId'])
+      ->setMethods(['getBillingAddress', 'getEntityId'])
       ->getMock();
 
     $this->addressMock = $this->getMockBuilder(Address::class)
@@ -219,7 +219,7 @@ class SendTest extends \PHPUnit_Framework_TestCase
       ->willReturn($orderId);
 
     $this->orderMock->expects($this->once())
-      ->method('getShippingAddress')
+      ->method('getBillingAddress')
       ->willReturn($this->addressMock);
 
     $this->addressMock->expects($this->once())
@@ -274,7 +274,7 @@ class SendTest extends \PHPUnit_Framework_TestCase
       ->willReturn($orderId);
 
     $this->orderMock->expects($this->once())
-      ->method('getShippingAddress')
+      ->method('getBillingAddress')
       ->willReturn($this->addressMock);
 
     $this->addressMock->expects($this->once())
@@ -286,7 +286,7 @@ class SendTest extends \PHPUnit_Framework_TestCase
 
     $this->messageManagerMock->expects($this->once())
       ->method('addErrorMessage')
-      ->with('The shipping telephone number did not opt-in for SMS notifications.')
+      ->with('The billing telephone number did not opt-in for SMS notifications.')
       ->willReturnSelf();
 
     $this->resultRedirectMock->expects($this->once())

--- a/Test/Unit/Model/Adapter/Order/InvoiceTest.php
+++ b/Test/Unit/Model/Adapter/Order/InvoiceTest.php
@@ -159,12 +159,12 @@ class InvoiceTest extends \PHPUnit_Framework_TestCase
       ->setMethods([
         'getIncrementId', 'getTotalQtyOrdered', 'getCustomerFirstname',
         'getCustomerLastname', 'getGrandTotal', 'getStoreName',
-        'getShippingAddress'
+        'getBillingAddress'
       ])
       ->getMock();
 
     $this->orderMock->expects($this->atLeastOnce())
-      ->method('getShippingAddress')
+      ->method('getBillingAddress')
       ->willReturn($this->addressMock);
 
     $this->orderMock->expects($this->once())

--- a/Test/Unit/Model/Adapter/OrderTest.php
+++ b/Test/Unit/Model/Adapter/OrderTest.php
@@ -155,12 +155,12 @@ class OrderTest extends \PHPUnit_Framework_TestCase
       ->setMethods([
         'getIncrementId', 'getTotalQtyOrdered', 'getCustomerFirstname',
         'getCustomerLastname', 'getGrandTotal', 'getStoreName',
-        'getShippingAddress'
+        'getBillingAddress'
       ])
       ->getMock();
 
     $this->orderMock->expects($this->atLeastOnce())
-      ->method('getShippingAddress')
+      ->method('getBillingAddress')
       ->willReturn($this->addressMock);
 
     $this->orderMock->expects($this->once())

--- a/Test/Unit/Observer/Sales/Order/Invoice/RegisterTest.php
+++ b/Test/Unit/Observer/Sales/Order/Invoice/RegisterTest.php
@@ -70,7 +70,7 @@ class RegisterTest extends \PHPUnit_Framework_TestCase
 
     $this->orderMock = $this->getMockBuilder(Order::class)
       ->disableOriginalConstructor()
-      ->setMethods(['getShippingAddress'])
+      ->setMethods(['getBillingAddress'])
       ->getMock();
 
     $this->addressMock = $this->getMockBuilder(Address::class)
@@ -106,7 +106,7 @@ class RegisterTest extends \PHPUnit_Framework_TestCase
       ->willReturn($this->orderMock);
 
     $this->orderMock->expects($this->once())
-      ->method('getShippingAddress')
+      ->method('getBillingAddress')
       ->willReturn($this->addressMock);
 
     $this->addressMock->expects($this->once())
@@ -135,38 +135,12 @@ class RegisterTest extends \PHPUnit_Framework_TestCase
       ->willReturn($this->orderMock);
 
     $this->orderMock->expects($this->once())
-      ->method('getShippingAddress')
+      ->method('getBillingAddress')
       ->willReturn($this->addressMock);
 
     $this->addressMock->expects($this->once())
       ->method('getSmsAlert')
       ->willReturn(false);
-
-    $this->invoiceAdapterMock->expects($this->never())
-      ->method('sendOrderSms');
-
-    $this->register->execute($this->observerMock);
-  }
-
-  public function testExecuteWithoutShippingAddress() {
-    $this->helperMock->expects($this->once())
-      ->method('isTwilioEnabled')
-      ->willReturn(true);
-
-    $this->observerMock->expects($this->once())
-      ->method('getInvoice')
-      ->willReturn($this->invoiceMock);
-
-    $this->invoiceMock->expects($this->once())
-      ->method('getOrder')
-      ->willReturn($this->orderMock);
-
-    $this->orderMock->expects($this->once())
-      ->method('getShippingAddress')
-      ->willReturn(null);
-
-    $this->addressMock->expects($this->never())
-      ->method('getSmsAlert');
 
     $this->invoiceAdapterMock->expects($this->never())
       ->method('sendOrderSms');

--- a/Test/Unit/Observer/Sales/OrderAfterTest.php
+++ b/Test/Unit/Observer/Sales/OrderAfterTest.php
@@ -61,7 +61,7 @@ class OrderAfterTest extends \PHPUnit_Framework_TestCase
 
     $this->orderMock = $this->getMockBuilder(Order::class)
       ->disableOriginalConstructor()
-      ->setMethods(['getShippingAddress'])
+      ->setMethods(['getBillingAddress'])
       ->getMock();
 
     $this->addressMock = $this->getMockBuilder(Address::class)
@@ -93,7 +93,7 @@ class OrderAfterTest extends \PHPUnit_Framework_TestCase
       ->willReturn($this->orderMock);
 
     $this->orderMock->expects($this->once())
-      ->method('getShippingAddress')
+      ->method('getBillingAddress')
       ->willReturn($this->addressMock);
 
     $this->addressMock->expects($this->once())
@@ -118,34 +118,12 @@ class OrderAfterTest extends \PHPUnit_Framework_TestCase
       ->willReturn($this->orderMock);
 
     $this->orderMock->expects($this->once())
-      ->method('getShippingAddress')
+      ->method('getBillingAddress')
       ->willReturn($this->addressMock);
 
     $this->addressMock->expects($this->once())
       ->method('getSmsAlert')
       ->willReturn(false);
-
-    $this->orderAdapterMock->expects($this->never())
-      ->method('sendOrderSms');
-
-    $this->orderAfter->execute($this->observerMock);
-  }
-
-  public function testExecuteWithoutShippingAddress() {
-    $this->helperMock->expects($this->once())
-      ->method('isTwilioEnabled')
-      ->willReturn(true);
-
-    $this->observerMock->expects($this->once())
-      ->method('getOrder')
-      ->willReturn($this->orderMock);
-
-    $this->orderMock->expects($this->once())
-      ->method('getShippingAddress')
-      ->willReturn(null);
-
-    $this->addressMock->expects($this->never())
-      ->method('getSmsAlert');
 
     $this->orderAdapterMock->expects($this->never())
       ->method('sendOrderSms');

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -48,7 +48,7 @@
         </field>
         <field id="message" translate="label" type="textarea" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
           <label>Message</label>
-          <comment><![CDATA[Variables: {{order.increment_id}}, {{order.qty}}, {{shipment.firstname}}, {{shipment.lastname}}, {{order.grandtotal}}, {{storename}}]]></comment>
+          <comment><![CDATA[Variables: {{order.increment_id}}, {{order.qty}}, {{billing.firstname}}, {{billing.lastname}}, {{order.grandtotal}}, {{storename}}]]></comment>
         </field>
       </group>
       <group id="shipment" translate="label" type="text" sortOrder="20" showInDefault="1" showInWebsite="1" showInStore="1">
@@ -70,7 +70,7 @@
         </field>
         <field id="message" translate="label" type="textarea" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">
           <label>Message</label>
-          <comment><![CDATA[Variables: {{invoice.qty}}, {{invoice.grandtotal}}, {{invoice.increment_id}}, {{order.increment_id}}, {{order.qty}}, {{shipment.firstname}}, {{shipment.firstname}}, {{storename}}]]></comment>
+          <comment><![CDATA[Variables: {{invoice.qty}}, {{invoice.grandtotal}}, {{invoice.increment_id}}, {{order.increment_id}}, {{order.qty}}, {{billing.firstname}}, {{billing.firstname}}, {{storename}}]]></comment>
         </field>
       </group>
       <!--<group id="credit_memo" translate="label" type="text" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -23,4 +23,10 @@
   <type name="Magento\Checkout\Model\ShippingInformationManagement">
     <plugin name="wms_twilio_model_shippinginformationmanagement" type="Pmclain\Twilio\Plugin\Checkout\Model\ShippingInformationManagement" sortOrder="10" />
   </type>
+  <type name="Magento\Checkout\Model\PaymentInformationManagement">
+    <plugin name="wms_twilio_model_paymentinformationmanagement" type="Pmclain\Twilio\Plugin\Checkout\Model\PaymentInformationManagement" sortOrder="10" />
+  </type>
+  <type name="Magento\Checkout\Model\GuestPaymentInformationManagement">
+    <plugin name="wms_twilio_model_guestpaymentinformationmanagement" type="Pmclain\Twilio\Plugin\Checkout\Model\GuestPaymentInformationManagement" sortOrder="10" />
+  </type>
 </config>

--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -3,6 +3,12 @@ var config = {
     mixins: {
       'Magento_Checkout/js/action/set-shipping-information': {
         'Pmclain_Twilio/js/action/set-shipping-information-mixin': true
+      },
+      'Magento_Checkout/js/action/create-billing-address': {
+        'Pmclain_Twilio/js/action/create-billing-address-mixin': true
+      },
+      'Magento_Checkout/js/action/place-order': {
+        'Pmclain_Twilio/js/action/place-order-mixin': true
       }
     }
   }

--- a/view/frontend/templates/address/edit.phtml
+++ b/view/frontend/templates/address/edit.phtml
@@ -41,7 +41,8 @@
       </div>
     </div>
     <div class="field choice sms-alert">
-      <input type="checkbox" name="sms_alert" value="1" title="<?php echo __('Send SMS order notifications'); ?>" id="sms_alert" <?php echo $block->getAddress()->getCustomAttribute('sms_alert')->getValue() === '1' ? 'checked' : ''; ?>>
+      <?php $smsAlert = $block->getAddress()->getCustomAttribute('sms_alert') ? $block->getAddress()->getCustomAttribute('sms_alert')->getValue() : false; ?>
+      <input type="checkbox" name="sms_alert" value="1" title="<?php echo __('Send SMS order notifications'); ?>" id="sms_alert" <?php echo $smsAlert === '1' ? 'checked' : ''; ?>>
       <label for="sms_alert" class="label">
         <span><?php echo __('Send SMS notifications to the telephone number above.'); ?></span>
       </label>

--- a/view/frontend/web/js/action/create-billing-address-mixin.js
+++ b/view/frontend/web/js/action/create-billing-address-mixin.js
@@ -1,0 +1,35 @@
+/**
+ * Pmclain_Twilio extension
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the GPL v3 License
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://www.gnu.org/licenses/gpl.txt
+ *
+ * @category       Pmclain
+ * @package        Twilio
+ * @copyright      Copyright (c) 2017
+ * @license        https://www.gnu.org/licenses/gpl.txt GPL v3 License
+ */
+
+define([
+  'jquery',
+  'mage/utils/wrapper',
+  'Magento_Checkout/js/model/quote'
+], function($, wrapper, quote) {
+  'use strict';
+
+  return function (createBillingAddressAction) {
+    return wrapper.wrap(createBillingAddressAction, function(originalAction, addressData) {
+      var result = originalAction();
+      if(result['customAttributes'] === undefined) {
+        result['customAttributes'] = {};
+      }
+      result.customAttributes['sms_alert'] = addressData.sms_alert;
+
+      return result;
+    });
+  };
+});

--- a/view/frontend/web/js/action/place-order-mixin.js
+++ b/view/frontend/web/js/action/place-order-mixin.js
@@ -1,0 +1,36 @@
+/**
+ * Pmclain_Twilio extension
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the GPL v3 License
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://www.gnu.org/licenses/gpl.txt
+ *
+ * @category       Pmclain
+ * @package        Twilio
+ * @copyright      Copyright (c) 2017
+ * @license        https://www.gnu.org/licenses/gpl.txt GPL v3 License
+ */
+
+define([
+  'jquery',
+  'mage/utils/wrapper',
+  'Magento_Checkout/js/model/quote'
+], function($, wrapper, quote) {
+  'use strict';
+
+  return function (placeOrderAction) {
+    return wrapper.wrap(placeOrderAction, function(originalAction) {
+      var billingAddress = quote.billingAddress();
+      if(billingAddress['extension_attributes'] === undefined) {
+        billingAddress['extension_attributes'] = {};
+      }
+
+      billingAddress['extension_attributes']['sms_alert'] = billingAddress.customAttributes['sms_alert'] ? 1 : 0;
+
+      return originalAction();
+    });
+  };
+});


### PR DESCRIPTION
fixes #2 - changes the telephone number used for order and invoice alerts to billing address. The shipping notification is still sent to the shipping address telephone number. 